### PR TITLE
Specifying Node Version

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ This respository contains the exercises and sample applications used in [Steve's
 
 All of the lessons can be found at https://rxjs-fundamentals.netlify.app.
 
+## Node Requirements
+
+The recommended Node version for this course is `16.19.0`. You can use the [Node Version Manager or nvm](https://github.com/nvm-sh/nvm) to install the correct Node version.
+
 ## Getting Started
 
 You can get _everything_ started by running `npm start` and heading over to `http://localhost:1234`. If for some reason the combined command is giving you trouble, then you can run each of the following separate terminal windows for the same effect.


### PR DESCRIPTION
There are a few dependency issues with Node 18+. I'm adding a requirement to use Node 16 to the instructions.

Closes #5 